### PR TITLE
Add token counting and message trimming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 openai
+tiktoken


### PR DESCRIPTION
## Summary
- add `tiktoken` dependency
- add helper functions for counting tokens and trimming conversation
- drop messages when token limit exceeded and warn the user

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_b_6865c6c02da8832c87f9ca7f4fd0e84e